### PR TITLE
feat: add shadow on nav when scrolled

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -3,6 +3,7 @@ import { NavLink, useHistory, useLocation } from 'react-router-dom';
 import { menuItemsLabel, menuItemsButton } from './NavBar.const';
 import { DrawerProps } from './NavBar.type';
 import images from '../../variables/images';
+import useScrollHeight from '../../hooks/useScrollHeight';
 
 const Drawer: React.FC<DrawerProps> = ({ open, close }) => {
   const _history = useHistory();
@@ -63,13 +64,17 @@ const NavBar: React.FC = () => {
   const [_drawerOpen, _setDrawerOpen] = useState(false);
   const _history = useHistory();
   const _location = useLocation();
+  const _height = useScrollHeight();
 
   const _activePath = (path: string) => path === _location.pathname;
   const _openDrawer = () => _setDrawerOpen(true);
   const _closeDrawer = () => _setDrawerOpen(false);
 
   return (
-    <nav className="flex flex-row bg-white lg:flex-row-reverse items-center justify-between py-4 px-4 lg:px-12 sticky top-0 z-30">
+    <nav 
+      className="flex flex-row bg-white lg:flex-row-reverse items-center justify-between py-4 px-4 lg:px-12 sticky top-0 z-30"
+      style={{ boxShadow: `0 ${_height/200 * 4}px ${_height/200 * 16}px rgba(0, 0, 0, 0.06)` }}
+    >
       <Drawer open={_drawerOpen} close={_closeDrawer} />
       <div onClick={_openDrawer} className="lg:hidden">
         <img

--- a/src/hooks/useScrollHeight.ts
+++ b/src/hooks/useScrollHeight.ts
@@ -1,0 +1,14 @@
+import { useState, useEffect } from 'react';
+
+const useScrollHeight = () => {
+  const [_scrollHeight, _setScrollHeight] = useState(0);
+
+  useEffect(() => {
+    window.addEventListener('scroll', (e: Event) => _setScrollHeight(window.scrollY));
+    return () => window.removeEventListener('scroll', () => {});
+  }, []);
+
+  return _scrollHeight;
+};
+
+export default useScrollHeight;


### PR DESCRIPTION
I have added shadow transition on the navbar every time the screen is scrolled

## Description
The description should be clear

## Motivation and Context
The addition of shadow makes the navbar looks separated from the main content screen.

## How Has This Been Tested?
Tested on Mozilla and Chrome. Running perfectly.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
