### PR TITLE
refactor: refactor core team cards

### DIFF
--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Layout from "../../components/Layout/Layout";
 import Card from '../../components/Card/Card';
 import images from "../../variables/images";
+import core from '../../variables/core';
 import { Helmet } from "react-helmet";
 
 const About : React.FC = () => {
@@ -77,24 +78,17 @@ const About : React.FC = () => {
         <Layout>
           <h1 className="text-center">Meet Our Core Team Members</h1>
           <div className="flex flex-wrap justify-center">
-            <div className="flex justify-center my-4 w-full sm:w-1/2 lg:w-1/3">
-              <Card
-                name="Andrew Cen"
-                position="Music Enthusiast"
-                picture="https://media-exp1.licdn.com/dms/image/C4E03AQE2CPQI3cenxg/profile-displayphoto-shrink_400_400/0?e=1601510400&v=beta&t=xVG-StdEOCFVLSdZ10YRKJX3lwv9tG90d47PyZ7K3VE"
-                iconType={['github', 'linkedin']}
-                iconURL={['https://github.com/werdna521', 'https://linkedin.com/linktoandrewcen']}
-              />
-            </div>
-            <div className="flex justify-center my-4 w-full sm:w-1/2 lg:w-1/3">
-              <Card
-                name="Jayaku Briliantio"
-                position="Machine Learning Developer"
-                picture="https://media-exp1.licdn.com/dms/image/C5603AQEqzJ1-J7hvRA/profile-displayphoto-shrink_400_400/0?e=1601510400&v=beta&t=pefyT7FWAOiZyx6_eTPz0Xi7zoT2_yYsglbFs74eLho"
-                iconType={['github', 'linkedin']}
-                iconURL={['https://github.com/ukayaj620', 'https://linkedin.com/neartojayakubriliantio']}
-              />
-            </div>
+            {core.members.map(({ name, position, picture, iconType, iconURL }, i) => (
+              <div className="flex justify-center my-4 w-full sm:w-1/2 lg:w-1/3">
+                <Card
+                  name={name}
+                  position={position}
+                  picture={picture}
+                  iconType={iconType}
+                  iconURL={iconURL}
+                />
+              </div>
+            ))}
           </div>
         </Layout>
       </div>

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -81,6 +81,7 @@ const About : React.FC = () => {
             {core.members.map(({ name, position, picture, iconType, iconURL }, i) => (
               <div className="flex justify-center my-4 w-full sm:w-1/2 lg:w-1/3">
                 <Card
+                  key={`core-team-card-${name}-${i}`}
                   name={name}
                   position={position}
                   picture={picture}

--- a/src/variables/core.ts
+++ b/src/variables/core.ts
@@ -1,0 +1,25 @@
+export default {
+  members: [
+    {
+      name: 'Andrew Cen',
+      position: 'Full Stack Developer | Machine Learning Enthusiast | Music Enthusiast',
+      picture: 'https://media-exp1.licdn.com/dms/image/C4E03AQE2CPQI3cenxg/profile-displayphoto-shrink_400_400/0?e=1601510400&v=beta&t=xVG-StdEOCFVLSdZ10YRKJX3lwv9tG90d47PyZ7K3VE',
+      iconType: ['github', 'linkedin'],
+      iconURL: ['https://github.com/werdna521', 'https://linkedin.com/linktoandrewcen'],
+    },
+    {
+      name: 'Jayaku Briliantio',
+      position: 'Machine Learning Developer',
+      picture: 'https://media-exp1.licdn.com/dms/image/C5603AQEqzJ1-J7hvRA/profile-displayphoto-shrink_400_400/0?e=1601510400&v=beta&t=pefyT7FWAOiZyx6_eTPz0Xi7zoT2_yYsglbFs74eLho',
+      iconType: ['github', 'linkedin'],
+      iconURL: ['https://github.com/ukayaj620', 'https://linkedin.com/neartojayakubriliantio'],
+    },
+    {
+      name: 'Tommy Salim',
+      position: 'UI/UX Designer',
+      picture: 'https://media-exp1.licdn.com/dms/image/C5603AQGC2Eyt4r4zjA/profile-displayphoto-shrink_400_400/0?e=1601510400&v=beta&t=28DhLwy2cXEVWYUxRNSNRoeqwSYCsOCjsizTyKdfmss',
+      iconType: ['linkedin'],
+      iconURL: ['https://www.linkedin.com/in/tommy-salim-72870a1a3/'],
+    },
+  ]
+};


### PR DESCRIPTION
The core team member cards used to be rendered one by one, meaning if there are 10 core team members, there will be 10 components, and the code will go wild and turn into spaghetti. Therefore, I refactor the code to just map an array of core team member instance from a separate file, so that the code will look cleaner and become much easier to maintain. Also, I added a new core team member to the list.